### PR TITLE
Calculate own scriptsize using sed and wc - removes need for hardcode…

### DIFF
--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -377,11 +377,11 @@ packagelist="base base-devel nano mesa lib32-mesa vulkan-radeon lib32-vulkan-rad
 			libva-mesa-driver"
 
 wget -q "https://archlinux.org/download/"
-current_release="$(cat index.html | grep "Current Release" | tail -c -16 | head -c +10)"
+current_release="$(grep "Current Release" index.html | tail -c -16 | head -c +10)"
 rm index.html
 
 echo "Downloading ${current_release} release"
-wget -q --show-progress -O arch.tar.gz https://mirror.rackspace.com/archlinux/iso/${current_release}/archlinux-bootstrap-${current_release}-x86_64.tar.gz
+wget -q --show-progress -O arch.tar.gz "https://mirror.rackspace.com/archlinux/iso/${current_release}/archlinux-bootstrap-${current_release}-x86_64.tar.gz"
 tar xf arch.tar.gz
 rm arch.tar.gz
 
@@ -404,7 +404,7 @@ echo "Include = /etc/pacman.d/mirrorlist" >> "${bootstrap}"/etc/pacman.conf
 run_in_chroot pacman-key --init
 run_in_chroot pacman-key --populate archlinux
 run_in_chroot pacman -Syu --noconfirm
-run_in_chroot pacman --noconfirm -S ${packagelist}
+run_in_chroot pacman --noconfirm -S "${packagelist}"
 run_in_chroot pacman --noconfirm -Scc
 run_in_chroot locale-gen
 

--- a/create-conty.sh
+++ b/create-conty.sh
@@ -4,7 +4,7 @@
 
 script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
-# Builtin suqashfuse supports only lz4 and zstd
+# Builtin squashfuse supports only lz4 and zstd
 # So choose either lz4 or zstd
 squashfs_compressor="lz4"
 compressor_arguments="-Xhc"

--- a/squashfs-start.sh
+++ b/squashfs-start.sh
@@ -3,7 +3,7 @@
 ## Dependencies: fuse2 tar
 
 # Prevent launching as root
-if [ -z $ALLOW_ROOT ]; then
+if [ -z "$ALLOW_ROOT" ]; then
 	if [ $EUID = 0 ]; then
 		echo "Do not run this app as root!"
 		echo
@@ -24,7 +24,7 @@ working_dir=/tmp/"$(basename "$0")"_"$(id -un)"_$RANDOM
 # a problem with mounting the squashfs image due to an incorrectly calculated offset.
 
 # The size of this script
-scriptsize=4101
+scriptsize="$(sed -n '/#!/,/^#ENDSCRIPT/p' "$0" | wc -c)"
 
 # The size of the utils.tar archive
 # utils.tar contains bwrap and squashfuse binaries
@@ -132,7 +132,7 @@ run_bwrap () {
 			--ro-bind-try /etc/nsswitch.conf /etc/nsswitch.conf \
 			--proc /proc \
 			--ro-bind-try /usr/local /usr/local \
-			${dirs} ${unshare} ${net} \
+			"${dirs}" "${unshare}" "${net}" \
 			--setenv PATH "/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib/jvm/default/bin:${PATH}" \
 			"$@"
 }
@@ -156,3 +156,4 @@ fi
 rm -rf "${working_dir}"
 
 exit
+#ENDSCRIPT

--- a/squashfs-start.sh
+++ b/squashfs-start.sh
@@ -141,8 +141,7 @@ run_bwrap () {
 mkdir -p "${working_dir}"/mnt
 "${fmount}" -u "${working_dir}"/mnt 2>/dev/null || umount "${working_dir}"/mnt 2>/dev/null
 
-"${sfuse}" -o offset="${offset}" "${script}" "${working_dir}"/mnt
-if [ $? = 0 ]; then
+if "${sfuse}" -o offset="${offset}" "${script}" "${working_dir}"/mnt ; then
 	echo "Running Conty"
 	run_bwrap "$@"
 


### PR DESCRIPTION
…d size

The script could calculate its own size, so hardcoding it would be no longer necessary.
Pulls in `sed` and `wc`, which might not be desired.

`#ENDSCRIPT` could be replaced with `^exit` of course, but probably better to use a clear separator.
