### PR TITLE
Use curl instead of wget

### DIFF
--- a/conty-start.sh
+++ b/conty-start.sh
@@ -431,7 +431,7 @@ if ([ "$1" = "-u" ] || [ "$1" = "-U" ]) && [ -z "${script_is_symlink}" ]; then
 	# Download or extract the utils.tar.gz and the init script depending
 	# on what command line argument is used (-u or -U)
 	clear
-	if [ "$1" = "-U" ] && command -v wget 1>/dev/null; then
+	if [ "$1" = "-U" ] && command -v curl 1>/dev/null; then
 		if [ "${dwarfs_image}" = 1 ]; then
 			utils="utils_dwarfs.tar.gz"
 		else
@@ -439,8 +439,8 @@ if ([ "$1" = "-u" ] || [ "$1" = "-U" ]) && [ -z "${script_is_symlink}" ]; then
 		fi
 
 		echo "Downloading the init script and the utils"
-		wget -q --show-progress "https://github.com/Kron4ek/Conty/raw/master/conty-start.sh"
-		wget -q --show-progress -O utils.tar.gz "https://github.com/Kron4ek/Conty/raw/master/${utils}"
+		curl -#LO "https://github.com/Kron4ek/Conty/raw/master/conty-start.sh"
+		curl -#Lo utils.tar.gz "https://github.com/Kron4ek/Conty/raw/master/${utils}"
 	fi
 
 	if [ ! -s conty-start.sh ] || [ ! -s utils.tar.gz ]; then

--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Dependencies: wget tar gzip grep sha256sum
+# Dependencies: curl tar gzip grep sha256sum
 # Root rights are required
 
 if [ $EUID != 0 ]; then
@@ -9,8 +9,8 @@ if [ $EUID != 0 ]; then
 	exit 1
 fi
 
-if ! command -v wget 1>/dev/null; then
-	echo "wget is required!"
+if ! command -v curl 1>/dev/null; then
+	echo "curl is required!"
 	exit 1
 fi
 
@@ -141,8 +141,8 @@ export packagelist="${audio_pkgs} ${video_pkgs} ${wine_pkgs} \
 	openbox obs-studio gamehub minigalaxy legendary gamescope \
 	pcsx2-git multimc5 yt-dlp bottles playonlinux"
 
-wget -q --show-progress -O chaotic-keyring.pkg.tar.zst 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst'
-wget -q --show-progress -O chaotic-mirrorlist.pkg.tar.zst 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'
+curl -#LO 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst'
+curl -#LO 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst'
 
 if [ ! -s chaotic-keyring.pkg.tar.zst ] || [ ! -s chaotic-mirrorlist.pkg.tar.zst ]; then
 	echo "Seems like Chaotic-AUR keyring or mirrorlist is currently unavailable"
@@ -157,10 +157,8 @@ bootstrap_urls="mirror.osbeck.com \
 echo "Downloading Arch Linux bootstrap"
 
 for link in ${bootstrap_urls}; do
-	wget -q --show-progress -O archlinux-bootstrap-x86_64.tar.gz \
-	 "https://${link}/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.gz"
-	wget -q --show-progress -O sha256sums.txt \
-	 "https://${link}/archlinux/iso/latest/sha256sums.txt"
+	curl -#LO "https://${link}/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.gz"
+	curl -#LO "https://${link}/archlinux/iso/latest/sha256sums.txt"
 
 	if [ -s sha256sums.txt ]; then
 		cat sha256sums.txt | grep bootstrap-x86_64 > sha256.txt

--- a/create-conty.sh
+++ b/create-conty.sh
@@ -38,7 +38,7 @@ fi
 
 if [ ! -f "${utils}" ] || [ "$(wc -c < "${utils}")" -lt 1000 ]; then
 	rm -f "${utils}"
-	wget -q --show-progress "https://github.com/Kron4ek/Conty/raw/master/${utils}"
+	curl -#LO "https://github.com/Kron4ek/Conty/raw/master/${utils}"
 fi
 
 if [ ! -f conty-start.sh ]; then

--- a/create-utils.sh
+++ b/create-utils.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# General build dependencies: gawk grep lz4 zstd wget gcc make autoconf
+# General build dependencies: gawk grep lz4 zstd curl gcc make autoconf
 # 	libtool pkgconf libcap fuse2 (or fuse3) lzo xz zlib findutils
 #
 # Dwarfs build dependencies: fuse2 (or fuse3) openssl jemalloc
@@ -30,17 +30,17 @@ export LDFLAGS="-Wl,-O1,--sort-common,--as-needed"
 mkdir -p "${script_dir}"/build-utils
 cd "${script_dir}"/build-utils || exit 1
 
-wget -q --show-progress -O lz4.tar.gz https://github.com/lz4/lz4/archive/refs/tags/v${lz4_version}.tar.gz
-wget -q --show-progress -O zstd.tar.gz https://github.com/facebook/zstd/archive/refs/tags/v${zstd_version}.tar.gz
-wget -q --show-progress -O bwrap.tar.gz https://github.com/containers/bubblewrap/archive/refs/tags/v${bwrap_version}.tar.gz
+curl -#Lo lz4.tar.gz https://github.com/lz4/lz4/archive/refs/tags/v${lz4_version}.tar.gz
+curl -#Lo zstd.tar.gz https://github.com/facebook/zstd/archive/refs/tags/v${zstd_version}.tar.gz
+curl -#Lo bwrap.tar.gz https://github.com/containers/bubblewrap/archive/refs/tags/v${bwrap_version}.tar.gz
 
 tar xf lz4.tar.gz
 tar xf zstd.tar.gz
 tar xf bwrap.tar.gz
 
 if [ "${build_dwarfs}" != "true" ]; then
-	wget -q --show-progress -O squashfuse.tar.gz https://github.com/vasi/squashfuse/archive/refs/tags/${squashfuse_version}.tar.gz
-	wget -q --show-progress -O sqfstools.tar.gz https://github.com/plougher/squashfs-tools/archive/refs/tags/${squashfs_tools_version}.tar.gz
+	curl -#Lo squashfuse.tar.gz https://github.com/vasi/squashfuse/archive/refs/tags/${squashfuse_version}.tar.gz
+	curl -#Lo sqfstools.tar.gz https://github.com/plougher/squashfs-tools/archive/refs/tags/${squashfs_tools_version}.tar.gz
 
 	tar xf squashfuse.tar.gz
 	tar xf sqfstools.tar.gz


### PR DESCRIPTION
Unlike wget one can reasonably expect curl to be available just about everywhere.
It's a dependency of both pacman and rpm (not sure about apt) and at least 324 other packages according to the arch package stats.