### PR TITLE
Rewrite bootstrap creation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-root.x86_64
-utils/
-pkglist.x86_64.txt
+build/

--- a/README.md
+++ b/README.md
@@ -393,17 +393,17 @@ There are a few ways to update Conty and get the latest packages, use whichever 
 
 ### Manual
 
-1. Obtain Arch Linux bootstrap by using `create-arch-bootstrap.sh`. Before running it, you can edit variables in `settings.sh` if you want, for example, to include a different set of packages inside the container, or to include additional locales. Make sure you have enough free disk space, i recommend at least 10 GB of free space. Root rights are required for this step.
+1. Obtain Arch Linux bootstrap by using `create-arch-bootstrap.sh`. Before running it, you can edit variables in `settings.sh` if you want, for example, to include a different set of packages inside the container, or to include additional locales. Make sure you have enough free disk space, i recommend at least 10 GB of free space. Root rights are required if your kernel does not support user namespaces
 
     ```
     # ./create-arch-bootstrap.sh
     ```
-2. After that you can use `enter-chroot.sh` to chroot into the bootstrap and do some manual modifications (for instance, modify some files, install/remove packages, etc.). Root rights are needed for this step too. This is an optional step, which you can skip if you wish.
+2. After that you can use `enter-chroot.sh` to chroot into the bootstrap and do some manual modifications (for instance, modify some files, install/remove packages, etc.). This is an optional step, which you can skip if you wish. Root rights are required if your kernel does not support user namespaces
 
     ```
     # ./enter-chroot.sh
     ```
-3. Now use `create-conty.sh` to create a SquashFS (or DwarFS) image and create a ready-to-use Conty executable. Root rights are not needed for this step. By default a SquashFS image with zstd compression (level 19) will be created, however, if you want, you can edit variables in `settings.sh` and enable DwarFS, select a different compression algorithm and/or compression level.
+3. Now use `create-conty.sh` to create a SquashFS (or DwarFS) image and create a ready-to-use Conty executable. By default a SquashFS image with zstd compression (level 19) will be created, however, if you want, you can edit variables in `settings.sh` and enable DwarFS, select a different compression algorithm and/or compression level.
 
     ```
     $ ./create-conty.sh

--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -108,7 +108,7 @@ printf '%s\n' "${LOCALES[@]}" > /etc/locale.gen
 locale-gen
 
 stage "Setting up default mirrorlist"
-printf '%s\n' "$MIRRORLIST" > /etc/pacman.d/mirrorlist
+printf 'Server = %s\n' "${DEFAULT_MIRRORS[@]}" > /etc/pacman.d/mirrorlist
 
 stage "Setting up pacman config"
 info "Disabling extraction of nvidia firmware and man pages"

--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -31,8 +31,10 @@ if [ -z "$INSIDE_BOOTSTRAP" ]; then
 	check_command_available curl tar unshare
 
 	script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-	bootstrap="$script_dir/root.x86_64"
-
+	build_dir="$script_dir/$BUILD_DIR"
+	bootstrap="$build_dir"/root.x86_64
+	mkdir -p "$build_dir"
+	cd "$build_dir"
 
 	info "Downloading Arch Linux bootstrap sha256sum from $BOOTSTRAP_SHA256SUM_FILE_URL"
 	curl -#LO "$BOOTSTRAP_SHA256SUM_FILE_URL"
@@ -229,6 +231,6 @@ stage "Generating install info"
 info "Writing list of all installed packages to /pkglist.x86_64.txt"
 pacman -Q > /pkglist.x86_64.txt
 info "Writing list of licenses for installed packages to /pkglicenses.txt"
-pacman -Qi | grep -E '^Name|Licenses' |  cut -d ":" -f 2 | paste -d ' ' - - > /pkglicenses.txt
+pacman -Qi | grep -E '^Name|Licenses' | cut -d ":" -f 2 | paste -d ' ' - - > /pkglicenses.txt
 info "Writing build date to /version"
 date -u +"%d-%m-%Y %H:%M (DMY UTC)" > /version

--- a/create-arch-bootstrap.sh
+++ b/create-arch-bootstrap.sh
@@ -73,6 +73,10 @@ if [ -z "$INSIDE_BOOTSTRAP" ]; then
 		mount -o ro --rbind /dev "$bootstrap"/dev
 		mount none -t devpts "$bootstrap"/dev/pts
 		mount none -t tmpfs "$bootstrap"/dev/shm
+		if [ -d /var/cache/pacman/pkg ]; then
+			mkdir -p "$bootstrap"/var/cache/pacman/host_pkg
+			mount -o ro --bind /var/cache/pacman/pkg "$bootstrap"/var/cache/pacman/host_pkg
+		fi
 		rm -f "$bootstrap"/etc/resolv.conf
 		cp /etc/resolv.conf "$bootstrap"/etc/resolv.conf
 		# Default machine-id is unitialized and systemd-tmpfiles throws some warnings
@@ -154,8 +158,10 @@ if [ "${#AUR_PACKAGES[@]}" -ne 0 ]; then
 	info "Disabling debug option in makepkg"
 	sed -i 's/\(OPTIONS=(.*\)\(debug.*)\)/\1!\2/' /etc/makepkg.conf
 fi
+info "Enabling fetch of packages from host pacman cache"
+sed -i 's!#CacheDir.*!CacheDir = /var/cache/pacman/pkg /var/cache/pacman/host_pkg!' /etc/pacman.conf
 info "Disabling extraction of nvidia firmware and man pages"
-sed -i 's/#NoExtract   =/NoExtract   = usr\/lib\/firmware\/nvidia\/\* usr\/share\/man\/\*/' /etc/pacman.conf
+sed -i 's!#NoExtract.*!NoExtract = usr/lib/firmware/nvidia/\* usr/share/man/\*!' /etc/pacman.conf
 info "Enabling multilib repository"
 echo '
 [multilib]

--- a/create-conty.sh
+++ b/create-conty.sh
@@ -1,12 +1,47 @@
 #!/usr/bin/env bash
 
-# Dependencies: sed, squashfs-tools or dwarfs
+set -e
+
+source settings.sh
 
 script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-image_path="${script_dir}"/image
-bootstrap="${script_dir}"/root.x86_64
+build_dir="${script_dir}/$BUILD_DIR"
+utils_dir="${build_dir}/utils"
+image_path="${build_dir}"/image
+bootstrap="${build_dir}"/root.x86_64
 
-source "${bootstrap}"/settings.sh
+if [ ! -d "${bootstrap}" ]; then
+	echo "Bootstrap at $bootstrap is missing. Use the create-arch-bootstrap.sh script to create it"
+	exit 1
+fi
+
+if [ ! -f "$script_dir"/conty-start.sh ]; then
+	echo "conty-start.sh is required!"
+	exit 1
+fi
+
+if [ -n "$USE_DWARFS" ]; then
+	utils="utils_dwarfs.tar.gz"
+else
+	utils="utils.tar.gz"
+fi
+
+if [ ! -f "$utils" ]; then
+	echo "$utils is not available locally, trying to fetch them from repository"
+ 	if git config --get remote.origin.url; then
+		utils_url="$(git config --get remote.origin.url)/raw/$(git rev-parse --abbrev-ref HEAD)/$utils"
+	else
+		utils_url="https://github.com/Kron4ek/Conty/raw/master/$utils"
+   	fi
+	curl --output-dir "$build_dir" -#LO "$utils_url"
+fi
+
+echo "Extracting $utils"
+rm -rf "$utils_dir"
+if ! tar -C "$build_dir" -xzf "$utils"; then
+	echo "Error occured while trying to extract $utils"
+	exit 1
+fi
 
 launch_wrapper () {
 	if [ -n "${USE_SYS_UTILS}" ]; then
@@ -17,119 +52,48 @@ launch_wrapper () {
 
 		"$@"
 	else
-		"${script_dir}"/utils/ld-linux-x86-64.so.2 --library-path "${script_dir}"/utils "${script_dir}"/utils/"$@"
+		PATH="${utils_dir}:$PATH" "${utils_dir}"/ld-linux-x86-64.so.2 --library-path "${utils_dir}" "$@"
 	fi
 }
 
-if ! command -v sed 1>/dev/null; then
-	echo "sed is required"
-	exit 1
-fi
-
-cd "${script_dir}" || exit 1
-
-if [ -n "$USE_DWARFS" ]; then
-	utils="utils_dwarfs.tar.gz"
-	compressor_command=(mkdwarfs -i "${bootstrap}" -o "${image_path}" "${DWARFS_COMPRESSOR_ARGUMENTS[@]}")
-else
-	utils="utils.tar.gz"
-	compressor_command=(mksquashfs "${bootstrap}" "${image_path}" "${SQUASHFS_COMPRESSOR_ARGUMENTS[@]}")
-fi
-
-if [ ! -f "${utils}" ] || [ "$(wc -c < "${utils}")" -lt 100000 ]; then
- 	if git config --get remote.origin.url; then
-		utils_url="$(git config --get remote.origin.url)"/raw/"$(git rev-parse --abbrev-ref HEAD)"/${utils}
-	else
-		utils_url="https://github.com/Kron4ek/Conty/raw/master/${utils}"
-   	fi
-
-	rm -f "${utils}"
-	curl -#LO "${utils_url}"
-
-	if [ ! -f "${utils}" ] || [ "$(wc -c < "${utils}")" -lt 100000 ]; then
-		rm -f "${utils}"
-		curl -#LO "https://gitlab.com/-/project/61149207/uploads/ec7cdd4e77318f13c5f67d229f390c66/utils.tar"
-  		tar -xf utils.tar
-	fi
-fi
-
-if [ ! -f conty-start.sh ]; then
-	echo "conty-start.sh is required!"
-	exit 1
-fi
-
-rm -rf utils
-tar -zxf "${utils}"
-
-if [ $? != 0 ]; then
-	echo "Something is wrong with ${utils}"
-	exit 1
-fi
-
-# Check if selected compression algorithm is supported by mksquashfs
-if [ -n "${USE_SYS_UTILS}" ] && [ -z "$USE_DWARFS" ] && command -v grep 1>/dev/null; then
-	if ! mksquashfs 2>&1 | grep -q "${SQUASHFS_COMPRESSOR}"; then
-		echo "Seems like your mksquashfs doesn't support the selected"
-		echo "compression algorithm (${SQUASHFS_COMPRESSOR})."
-		echo
-		echo "Choose another algorithm and run the script again"
-
-		exit 1
-	fi
-fi
-
-echo
-echo "Creating Conty..."
-echo
-
 # Create the image
+echo "Creating Conty..."
 if [ ! -f "${image_path}" ] || [ -z "${USE_EXISTING_IMAGE}" ]; then
-	if [ ! -d "${bootstrap}" ]; then
-		echo "Distro bootstrap is required!"
-		echo "Use the create-arch-bootstrap.sh script to get it"
+	rm -f "${image_path}"
+	if [ -n "$USE_DWARFS" ]; then
+		launch_wrapper mkdwarfs -i "${bootstrap}" -o "${image_path}" "${DWARFS_COMPRESSOR_ARGUMENTS[@]}"
+	else
+		launch_wrapper mksquashfs "${bootstrap}" "${image_path}" "${SQUASHFS_COMPRESSOR_ARGUMENTS[@]}"
+	fi
+fi
+
+for util in init bash busybox; do
+	if [ ! -s "$utils_dir"/"$util" ]; then
+		echo "$utils_dir/$util does not exist or is empty"
 		exit 1
 	fi
+done
 
-	rm -f "${image_path}"
-	launch_wrapper "${compressor_command[@]}"
-fi
+utils_size="$(stat -c%s "$utils")"
+init_size="$(stat -c%s "$utils_dir"/init)"
+bash_size="$(stat -c%s "$utils_dir"/bash)"
+busybox_size="$(stat -c%s "$utils_dir"/busybox)"
 
-if command -v sed 1>/dev/null; then
-	utils_size="$(stat -c%s "${utils}")"
-	init_size=0
-	bash_size=0
-	busybox_size=0
+cp "$script_dir"/conty-start.sh "$build_dir"/conty-start.sh
+sed -i "s/init_size=.*/init_size=${init_size}/" "$build_dir"/conty-start.sh
+sed -i "s/bash_size=.*/bash_size=${bash_size}/" "$build_dir"/conty-start.sh
+sed -i "s/busybox_size=.*/busybox_size=${busybox_size}/" "$build_dir"/conty-start.sh
+sed -i "s/utils_size=.*/utils_size=${utils_size}/" "$build_dir"/conty-start.sh
 
-	if [ -s utils/init ]; then
-		init_size="$(stat -c%s utils/init)"
-	fi
-
-	if [ -s utils/bash ]; then
-		bash_size="$(stat -c%s utils/bash)"
-	fi
-
-	if [ -s utils/busybox ]; then
-		busybox_size="$(stat -c%s utils/busybox)"
-	fi
-
-	if [ "${init_size}" = 0 ] || [ "${bash_size}" = 0 ]; then
-		init_size=0
-		bash_size=0
-		rm -f utils/init utils/bash
-	fi
-
-	sed -i "s/init_size=.*/init_size=${init_size}/" conty-start.sh
-	sed -i "s/bash_size=.*/bash_size=${bash_size}/" conty-start.sh
-	sed -i "s/busybox_size=.*/busybox_size=${busybox_size}/" conty-start.sh
-	sed -i "s/utils_size=.*/utils_size=${utils_size}/" conty-start.sh
-
-	sed -i "s/script_size=.*/script_size=$(stat -c%s conty-start.sh)/" conty-start.sh
-	sed -i "s/script_size=.*/script_size=$(stat -c%s conty-start.sh)/" conty-start.sh
-fi
+sed -i "s/script_size=.*/script_size=$(stat -c%s conty-start.sh)/" "$build_dir"/conty-start.sh
+sed -i "s/script_size=.*/script_size=$(stat -c%s conty-start.sh)/" "$build_dir"/conty-start.sh
 
 # Combine the files into a single executable using cat
-cat utils/init utils/bash conty-start.sh utils/busybox "${utils}" "${image_path}" > conty.sh
-chmod +x conty.sh
-
-clear
+cat "$utils_dir"/init \
+	"$utils_dir"/bash \
+	"$build_dir"/conty-start.sh \
+	"$utils_dir"/busybox \
+	"$utils" \
+	"$image_path" > "$script_dir"/conty.sh
+chmod +x "$script_dir"/conty.sh
 echo "Conty created and ready to use!"

--- a/enter-chroot.sh
+++ b/enter-chroot.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
+set -e
+source settings.sh
 script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-bootstrap="${script_dir}"/root.x86_64
+build_dir="${script_dir}/$BUILD_DIR"
+bootstrap="$build_dir/root.x86_64"
 
 if [ ! -d "${bootstrap}" ]; then
-    echo "Bootstrap is missing"
+	echo "Bootstrap at $bootstrap is missing. Use the create-arch-bootstrap.sh script to create it"
     exit 1
 fi
 
@@ -14,7 +17,7 @@ enter_namespace() {
 	mount --rbind /dev "$bootstrap"/dev
 	mount none -t devpts "$bootstrap"/dev/pts
 	mount none -t tmpfs "$bootstrap"/dev/shm
-	chroot "$bootstrap" /usr/bin/env -i USER='root' HOME='/root' /bin/bash
+	chroot "$bootstrap" /usr/bin/env -i USER='root' HOME='/root' /bin/bash -c 'source /etc/profile; exec bash'
 }
 
 export bootstrap

--- a/enter-chroot.sh
+++ b/enter-chroot.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 
-# Root rights are required
-
-if [ $EUID != 0 ]; then
-    echo "Root rights are required!"
-
-    exit 1
-fi
-
 script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
-
 bootstrap="${script_dir}"/root.x86_64
 
 if [ ! -d "${bootstrap}" ]; then
@@ -17,31 +8,15 @@ if [ ! -d "${bootstrap}" ]; then
     exit 1
 fi
 
-# First unmount just in case
-umount -Rl "${bootstrap}"
+enter_namespace() {
+	mount --bind "$bootstrap"/ "$bootstrap"/
+	mount --rbind /proc "$bootstrap"/proc
+	mount --rbind /dev "$bootstrap"/dev
+	mount none -t devpts "$bootstrap"/dev/pts
+	mount none -t tmpfs "$bootstrap"/dev/shm
+	chroot "$bootstrap" /usr/bin/env -i USER='root' HOME='/root' /bin/bash
+}
 
-mount --bind "${bootstrap}" "${bootstrap}"
-mount -t proc /proc "${bootstrap}"/proc
-mount --bind /sys "${bootstrap}"/sys
-mount --make-rslave "${bootstrap}"/sys
-mount --bind /dev "${bootstrap}"/dev
-mount --bind /dev/pts "${bootstrap}"/dev/pts
-mount --bind /dev/shm "${bootstrap}"/dev/shm
-mount --make-rslave "${bootstrap}"/dev
-
-rm -f "${bootstrap}"/etc/resolv.conf
-cp /etc/resolv.conf "${bootstrap}"/etc/resolv.conf
-
-mkdir -p "${bootstrap}"/run/shm
-
-echo "Entering chroot"
-echo "To exit the chroot, perform the \"exit\" command"
-chroot "${bootstrap}" /usr/bin/env LANG=en_US.UTF-8 TERM=xterm PATH="/bin:/sbin:/usr/bin:/usr/sbin" /bin/bash
-echo "Exiting chroot"
-
-umount -l "${bootstrap}"
-umount "${bootstrap}"/proc
-umount "${bootstrap}"/sys
-umount "${bootstrap}"/dev/pts
-umount "${bootstrap}"/dev/shm
-umount "${bootstrap}"/dev
+export bootstrap
+export -f enter_namespace
+unshare --uts --ipc --user --mount --map-auto --map-root-user --pid --fork -- bash -c enter_namespace

--- a/settings.sh
+++ b/settings.sh
@@ -3,7 +3,7 @@
 # Packages to install
 # You can add packages that you want and remove packages that you don't need
 # Apart from packages from the official Arch repos, you can also specify
-# packages from the Chaotic-AUR repo
+# packages from the Chaotic-AUR repo if you set ENABLE_CHAOTIC_AUR
 PACKAGES=(
 	# audio
 	alsa-lib lib32-alsa-lib alsa-plugins lib32-alsa-plugins libpulse
@@ -56,6 +56,10 @@ PACKAGES=(
 
 # If you want to install AUR packages, specify them in this variable
 AUR_PACKAGES=(faugus-launcher-git)
+
+# Chaotic-AUR is a repository containing precompiled packages from AUR
+# Set this variable to any value if you want to enable id
+ENABLE_CHAOTIC_AUR=1
 
 # ALHP is a repository containing packages from the official Arch Linux
 # repos recompiled with -O3, LTO and optimizations for modern CPUs for

--- a/settings.sh
+++ b/settings.sh
@@ -101,20 +101,13 @@ LOCALES=(
 	'hi_IN UTF-8'
 )
 
-# Content of pacman mirrorrlist file before reflector is installed and used to fetch new one
+# Pacman mirrors to use before reflector is installed and used to fetch new one
 # shellcheck disable=2016
-MIRRORLIST='
-Server = https://mirror1.sl-chat.ru/archlinux/$repo/os/$arch
-Server = https://mirror3.sl-chat.ru/archlinux/$repo/os/$arch
-Server = https://us.mirrors.cicku.me/archlinux/$repo/os/$arch
-Server = https://mirror.osbeck.com/archlinux/$repo/os/$arch
-Server = https://md.mirrors.hacktegic.com/archlinux/$repo/os/$arch
-Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
-Server = https://mirror.qctronics.com/archlinux/$repo/os/$arch
-Server = https://arch.mirror.constant.com/$repo/os/$arch
-Server = https://america.mirror.pkgbuild.com/$repo/os/$arch
-Server = https://mirror.tmmworkshop.com/archlinux/$repo/os/$arch
-'
+DEFAULT_MIRRORS=(
+	'https://geo.mirror.pkgbuild.com/$repo/os/$arch'
+	'https://ftpmirror.infania.net/mirror/archlinux/$repo/os/$arch'
+	'https://mirror.rackspace.com/archlinux/$repo/os/$arch'
+)
 
 # Enable this variable to use the system-wide mksquashfs/mkdwarfs instead
 # of those provided by the Conty project
@@ -143,12 +136,9 @@ DWARFS_COMPRESSOR_ARGUMENTS=(
 # List of links to arch bootstrap archive
 # Conty will try to download each one of them sequentially
 BOOTSTRAP_DOWNLOAD_URLS=(
-	'https://arch.hu.fo/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
-	'https://mirror.cyberbits.eu/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
-	'https://mirror.osbeck.com/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
-	'https://mirror.lcarilla.de/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
-	'https://mirror.moson.org/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
-	'https://mirror.f4st.host/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
+	'https://geo.mirror.pkgbuild.com/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
+	'https://ftpmirror.infania.net/mirror/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
+	'https://mirror.rackspace.com/archlinux/iso/latest/archlinux-bootstrap-x86_64.tar.zst'
 )
 
 # sha256sums.txt file to verify downloaded bootstrap archive with

--- a/settings.sh
+++ b/settings.sh
@@ -116,13 +116,11 @@ USE_SYS_UTILS=0
 # Supported compression algorithms: lz4, zstd, gzip, xz, lzo
 # These are the algorithms supported by the integrated squashfuse
 # However, your squashfs-tools (mksquashfs) may not support some of them
-SQUASHFS_COMPRESSOR="zstd"
-SQUASHFS_COMPRESSOR_ARGUMENTS=(-b 1M -comp "${SQUASHFS_COMPRESSOR}" -Xcompression-level 19)
+SQUASHFS_COMPRESSOR_ARGUMENTS=(-b 1M -comp zstd -Xcompression-level 19)
 
 # Uncomment these variables if your mksquashfs does not support zstd or
 # if you want faster compression/decompression (at the cost of compression ratio)
-#SQUASHFS_COMPRESSOR="lz4"
-#SQUASHFS_COMPRESSOR_ARGUMENTS=(-b 256K -comp "${SQUASHFS_COMPRESSOR}" -Xhc)
+#SQUASHFS_COMPRESSOR_ARGUMENTS=(-b 256K -comp lz4 -Xhc)
 
 # Set to any value to Use DwarFS instead of SquashFS
 USE_DWARFS=
@@ -147,3 +145,6 @@ BOOTSTRAP_SHA256SUM_FILE_URL='https://archlinux.org/iso/latest/sha256sums.txt'
 # Set to any value to use an existing image if it exists
 # Otherwise the script will always create a new image
 USE_EXISTING_IMAGE=
+
+# Directory where image will be built relative to script directory
+BUILD_DIR="build"

--- a/settings.sh
+++ b/settings.sh
@@ -14,9 +14,8 @@ PACKAGES=(
 	mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon
 	vulkan-intel lib32-vulkan-intel
 	vulkan-icd-loader lib32-vulkan-icd-loader vulkan-mesa-layers
-	lib32-vulkan-mesa-layers libva-mesa-driver lib32-libva-mesa-driver
-	libva-intel-driver lib32-libva-intel-driver intel-media-driver
-	mesa-utils vulkan-tools libva-utils lib32-mesa-utils
+	lib32-vulkan-mesa-layers libva-intel-driver lib32-libva-intel-driver
+	intel-media-driver mesa-utils vulkan-tools libva-utils lib32-mesa-utils
 	# wine
 	wine-staging winetricks-git wine-nine wineasio
 	freetype2 lib32-freetype2 libxft lib32-libxft
@@ -36,7 +35,7 @@ PACKAGES=(
 	libgcrypt lib32-libgcrypt ncurses lib32-ncurses ocl-icd lib32-ocl-icd
 	libxcrypt-compat lib32-libxcrypt-compat libva lib32-libva sqlite lib32-sqlite
 	gtk3 lib32-gtk3 vulkan-icd-loader lib32-vulkan-icd-loader
-	sdl2 lib32-sdl2 vkd3d lib32-vkd3d libgphoto2
+	sdl2-compat lib32-sdl2-compat vkd3d lib32-vkd3d libgphoto2
 	openssl-1.1 lib32-openssl-1.1 libnm lib32-libnm
 	cabextract wget gamemode lib32-gamemode mangohud lib32-mangohud
 	# development
@@ -47,7 +46,7 @@ PACKAGES=(
 	retroarch retroarch-assets-ozone libretro-beetle-psx-hw sunshine
 	libretro-blastem libretro-bsnes libretro-dolphin duckstation
 	libretro-gambatte libretro-melonds libretro-mgba libretro-nestopia
-	libretro-parallel-n64 libretro-pcsx2 libretro-picodrive libretro-ppsspp
+	libretro-parallel-n64 libretro-picodrive libretro-ppsspp
 	libretro-retrodream libretro-yabause pcsx2-avx-git
 	# extra
 	nano ttf-dejavu ttf-liberation firefox mpv geany pcmanfm


### PR DESCRIPTION
- Changed it to use namespaces to allow it to run without root privileges on systems that have user namespaces enabled
- Rewritten it to fully separate parts that run inside chroot from parts that run outside of it.  This is mainly due to not being able to persist namespace mount between commands without root privileges but also that I think it is cleaner that way.
- Allowed disabling Chaotic-AUR repository.
- Moved all build files to /build sub directory.
- Made it so that pacman host cache is mounted in chroot when it is available to speed up chroot build process.